### PR TITLE
Add Admin model, factory, migration

### DIFF
--- a/app/Models/Admin.php
+++ b/app/Models/Admin.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * @use HasFactory<\Database\Factories\AdminFactory>
+ */
+class Admin extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'password',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var list<string>
+     */
+    protected $hidden = [
+        'password',
+    ];
+}

--- a/database/factories/AdminFactory.php
+++ b/database/factories/AdminFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Hash;
+
+/**
+ * @extends Factory<\App\Models\Admin>
+ */
+class AdminFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'password' => Hash::make('password'),
+        ];
+    }
+}

--- a/database/migrations/0001_01_01_000004_create_admins_table.php
+++ b/database/migrations/0001_01_01_000004_create_admins_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('admins', function (Blueprint $table) {
+            $table->id()->comment('ID');
+            $table->string('name', 255)->unique()->comment('ユーザ名');
+            $table->string('password', 255)->comment('パスワード');
+            $table->timestamp('deleted_at')->nullable()->comment('削除日');
+            $table->timestamp('updated_at')->useCurrent()->useCurrentOnUpdate()->comment('更新日時');
+            $table->timestamp('created_at')->useCurrent()->comment('作成日時');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('admins');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\User;
 use App\Models\Hotel;
+use App\Models\Admin;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -21,6 +22,10 @@ class DatabaseSeeder extends Seeder
         User::factory()->create([
             'name' => 'Test User',
             'email' => 'test@example.com',
+        ]);
+
+        Admin::factory()->create([
+            'name' => 'Admin User',
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- create admins table with comments on each column
- add Admin model with soft deletes
- add AdminFactory for seeding
- seed a sample admin via DatabaseSeeder

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cb8ace4148329bfedf627ce3d03ff